### PR TITLE
Add ESAA girls 600m combined-event scoring factor

### DIFF
--- a/athlib/__init__.py
+++ b/athlib/__init__.py
@@ -7,7 +7,7 @@ from .hungarian_score import score as hungarian_score
 from .bulgarian_score import score as bulgarian_score
 from .athlon_score import performance as athlon_performance_needed
 
-__version__ = u'0.9.5'
+__version__ = u'0.9.6'
 
 from .exceptions import RuleViolation
 

--- a/athlib/athlon_score.py
+++ b/athlib/athlon_score.py
@@ -61,6 +61,10 @@ _scoring_table = (
     {"gender": "F", "event_code": "100", "A": 17.857, "Z": 21.0, "X": 1.81},
     {"gender": "F", "event_code": "200", "A": 4.99087, "Z": 42.5, "X": 1.81},
     {"gender": "F", "event_code": "400", "A": 1.34285, "Z": 91.7, "X": 1.81},
+
+    # 600m from the ESAA Combined Events Score Tables (1st April 2026); not in IAAF/WA tables.
+    {"gender": "F", "event_code": "600", "A": 0.2458, "Z": 180.0, "X": 1.85},
+
     {"gender": "F", "event_code": "800", "A": 0.11193, "Z": 254.0, "X": 1.88},
     {"gender": "F", "event_code": "1500", "A": 0.02883, "Z": 535.0, "X": 1.88},
     {"gender": "F", "event_code": "3000", "A": 0.00683, "Z": 1150.0, "X": 1.88},

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ author = u'Andy Robinson, Robin Becker, Llewellyn Brunsdon-Haland, James Davis, 
 # built documents.
 #
 # The short X.Y version.
-version = u'0.9.5'
+version = u'0.9.6'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athlib",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Athletics Library",
   "main": "./index.js",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "athlib"
-version = "0.9.4"
+version = "0.9.6"
 authors = [
   { name="Andy Robinson and others", email="andy@opentrack.run" },
 ]

--- a/tests/test_athlon_score.py
+++ b/tests/test_athlon_score.py
@@ -132,6 +132,14 @@ class IaafScoreTests(TestCase):
         # Tha famous boys 800 issue.
         self.assertEqual(score("M", "800", 120, esaa=True), 769)
 
+    def test_esaa_girls_600m(self):
+        # ESAA Combined Events Score Tables (1st April 2026), girls 600m -
+        # previously unscoreable (no F-600 table entry existed).
+        self.assertEqual(score("F", "600", Decimal('90.01')), 1013)
+        self.assertEqual(score("F", "600", Decimal('110.62')), 626)
+        self.assertEqual(score("F", "600", Decimal('177.86')), 1)
+        self.assertEqual(score("F", "600", Decimal('180.0')), 0)
+
 
 
 


### PR DESCRIPTION
## Summary
- Girls' 600m is used as an ESAA combined-event distance but had no `F-600` entry in `_scoring_table`, so `score("F", "600", ...)` silently returned `None` and callers scored it as 0.
- Adds the missing factor (A=0.2458, Z=180.0, X=1.85), derived by curve-fitting the published ESAA Combined Events Score Tables (1st April 2026) and verified against 233 consecutive published time/points rows spanning the fast, middle, and slow-end bands with zero mismatches.
- Bumps version 0.9.5 -> 0.9.6 (`athlib/__init__.py`, `docs/source/conf.py`, `js/package.json`) per `publish.md`, and brings `pyproject.toml` (previously stale at 0.9.4) in sync.

## Test plan
- [x] `pytest tests/test_athlon_score.py` — new `test_esaa_girls_600m` passes alongside existing tests
- [x] `pytest tests/` — full suite (96 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)