### PR TITLE
Add ESAA girls 150m combined-event scoring factor

### DIFF
--- a/athlib/__init__.py
+++ b/athlib/__init__.py
@@ -7,7 +7,7 @@ from .hungarian_score import score as hungarian_score
 from .bulgarian_score import score as bulgarian_score
 from .athlon_score import performance as athlon_performance_needed
 
-__version__ = u'0.9.6'
+__version__ = u'0.9.7'
 
 from .exceptions import RuleViolation
 

--- a/athlib/athlon_score.py
+++ b/athlib/athlon_score.py
@@ -59,6 +59,10 @@ _scoring_table = (
 
 
     {"gender": "F", "event_code": "100", "A": 17.857, "Z": 21.0, "X": 1.81},
+
+    # 150m from the ESAA Combined Events Score Tables (1st April 2026); not in IAAF/WA tables.
+    {"gender": "F", "event_code": "150", "A": 8.1894, "Z": 32.0, "X": 1.81},
+
     {"gender": "F", "event_code": "200", "A": 4.99087, "Z": 42.5, "X": 1.81},
     {"gender": "F", "event_code": "400", "A": 1.34285, "Z": 91.7, "X": 1.81},
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ author = u'Andy Robinson, Robin Becker, Llewellyn Brunsdon-Haland, James Davis, 
 # built documents.
 #
 # The short X.Y version.
-version = u'0.9.6'
+version = u'0.9.7'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athlib",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Athletics Library",
   "main": "./index.js",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "athlib"
-version = "0.9.6"
+version = "0.9.7"
 authors = [
   { name="Andy Robinson and others", email="andy@opentrack.run" },
 ]

--- a/tests/test_athlon_score.py
+++ b/tests/test_athlon_score.py
@@ -140,6 +140,14 @@ class IaafScoreTests(TestCase):
         self.assertEqual(score("F", "600", Decimal('177.86')), 1)
         self.assertEqual(score("F", "600", Decimal('180.0')), 0)
 
+    def test_esaa_girls_150m(self):
+        # ESAA 2026 tables, girls 150m - previously unscoreable (no F-150 entry).
+        self.assertEqual(score("F", "150", Decimal('17.40')), 1048)
+        self.assertEqual(score("F", "150", Decimal('20.00')), 735)
+        self.assertEqual(score("F", "150", Decimal('25.00')), 277)
+        self.assertEqual(score("F", "150", Decimal('30.00')), 28)
+        self.assertEqual(score("F", "150", Decimal('31.55')), 1)
+
 
 
 


### PR DESCRIPTION
## Summary
- Girls' 150m (ESAA Combined Events Score Tables, 1st April 2026) had no scoring entry, so `score("F", "150", ...)` silently returned `None`.
- Coefficients (A=8.1894, Z=32.0, X=1.81) derived by curve-fitting the published table, verified with zero mismatches against all 1505 published time/points rows.
- Version bumped 0.9.6 → 0.9.7, following the same pattern as the girls 600m addition (#55).

## Test plan
- [x] `pytest tests/test_athlon_score.py` passes, including new `test_esaa_girls_150m`
- [x] Full published table (1505 rows) verified against `score("F", "150", ...)` with zero mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)