### PR TITLE
Fix ESAA girls 600m combined-event scoring factor

### DIFF
--- a/athlib/athlon_score.py
+++ b/athlib/athlon_score.py
@@ -67,7 +67,7 @@ _scoring_table = (
     {"gender": "F", "event_code": "400", "A": 1.34285, "Z": 91.7, "X": 1.81},
 
     # 600m from the ESAA Combined Events Score Tables (1st April 2026); not in IAAF/WA tables.
-    {"gender": "F", "event_code": "600", "A": 0.2458, "Z": 180.0, "X": 1.85},
+    {"gender": "F", "event_code": "600", "A": 0.2457, "Z": 180.0, "X": 1.85},
 
     {"gender": "F", "event_code": "800", "A": 0.11193, "Z": 254.0, "X": 1.88},
     {"gender": "F", "event_code": "1500", "A": 0.02883, "Z": 535.0, "X": 1.88},


### PR DESCRIPTION
## Summary
- `athlon_score.py` had `A=0.2458` for the F-600 ESAA combined-events factor (added in #55 / 38be23c), derived by curve-fitting against published time/points rows
- The rulebook gives `A=0.2457` for this event
- The ~0.04% difference didn't happen to flip any of the integer-floored results already checked into `tests/test_athlon_score.py`, so the previous value passed those tests despite being wrong

## Test plan
- [x] `pytest tests/test_athlon_score.py` — all 9 tests pass with the corrected value